### PR TITLE
Update with new golang.org alias.

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"text/template"
 
-	"code.google.com/p/go.tools/godoc"
-	"code.google.com/p/go.tools/godoc/vfs"
+	"golang.org/x/tools/godoc"
+	"golang.org/x/tools/godoc/vfs"
 )
 
 var (


### PR DESCRIPTION
The go.tools repo is being deprecated, and this breaks the build.
Replacing with the golang.org/x/tools repo fixes things.
