### PR TITLE
Provide a way to supply an alternative template file

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,10 +90,6 @@ func readTemplate(name, data string) *template.Template {
 	return t
 }
 
-func readTemplates(p *godoc.Presentation, html bool) {
-	p.PackageText = readTemplate("package.txt", pkgTemplate)
-}
-
 func main() {
 	flag.Usage = usage
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ var (
 	// layout control
 	tabWidth       = flag.Int("tabwidth", 4, "tab width")
 	showTimestamps = flag.Bool("timestamps", false, "show timestamps with directory listings")
-	templateDir    = flag.String("templates", "", "directory containing alternate template files")
+	altPkgTemplate = flag.String("template", "", "alternate template")
 	showPlayground = flag.Bool("play", false, "enable playground in web interface")
 	showExamples   = flag.Bool("ex", false, "show examples in command line mode")
 	declLinks      = flag.Bool("links", true, "link identifiers to their declarations")
@@ -122,7 +122,11 @@ func main() {
 	pres.SrcMode = false
 	pres.HTMLMode = false
 
-	readTemplates(pres, false)
+	if *altPkgTemplate != "" {
+		pres.PackageText = readTemplate("package.txt", *altPkgTemplate)
+	} else {
+		pres.PackageText = readTemplate("package.txt", pkgTemplate)
+	}
 
 	if err := godoc.CommandLine(os.Stdout, fs, pres, flag.Args()); err != nil {
 		log.Print(err)

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
+	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -37,7 +38,7 @@ var (
 	// layout control
 	tabWidth       = flag.Int("tabwidth", 4, "tab width")
 	showTimestamps = flag.Bool("timestamps", false, "show timestamps with directory listings")
-	altPkgTemplate = flag.String("template", "", "alternate template")
+	altPkgTemplate = flag.String("template", "", "path to an alternate template file")
 	showPlayground = flag.Bool("play", false, "enable playground in web interface")
 	showExamples   = flag.Bool("ex", false, "show examples in command line mode")
 	declLinks      = flag.Bool("links", true, "link identifiers to their declarations")
@@ -123,7 +124,11 @@ func main() {
 	pres.HTMLMode = false
 
 	if *altPkgTemplate != "" {
-		pres.PackageText = readTemplate("package.txt", *altPkgTemplate)
+		buf, err := ioutil.ReadFile(*altPkgTemplate)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pres.PackageText = readTemplate("package.txt", string(buf))
 	} else {
 		pres.PackageText = readTemplate("package.txt", pkgTemplate)
 	}


### PR DESCRIPTION
In our project, we needed a way to change the template. It was not possible to use `templates` flag because it is not used anywhere in the code. Looks like you wanted to add this functionality and even added `readTemplates` method, but later decided not to.

Not sure if it makes sense to merge these changes, so feel free to do whatever you want with this PR.